### PR TITLE
Fix saving data policy in DAO

### DIFF
--- a/app/src/androidTest/java/com/piticlistudio/playednext/data/repository/datasource/dao/CompanyDaoServiceTest.kt
+++ b/app/src/androidTest/java/com/piticlistudio/playednext/data/repository/datasource/dao/CompanyDaoServiceTest.kt
@@ -35,7 +35,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun insertCompanyShouldStoreData() {
+    fun insertCompany_shouldStoreData() {
 
         val data = makeCompanyDao()
 
@@ -45,8 +45,19 @@ class CompanyDaoServiceTest {
         assertEquals(data.id, result!!.toInt())
     }
 
+    fun insertCompany_ignoresIfAlreadyStored() {
+
+        val data = makeCompanyDao()
+
+        val id = database?.companyDao()?.insertCompany(data)
+        val id2 = database?.companyDao()?.insertCompany(data)
+
+        assertTrue(id!! > 0L)
+        assertEquals(0L, id2)
+    }
+
     @Test
-    fun insertGameDeveloper() {
+    fun insertGameDeveloper_shouldStoreData() {
         val company = makeCompanyDao()
         val game = makeGameCache()
         val data = GameDeveloperDao(game.id, company.id)
@@ -60,7 +71,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun insertGamePublisher() {
+    fun insertGamePublisher_shouldStoreData() {
         val company = makeCompanyDao()
         val game = makeGameCache()
         val data = GamePublisherDao(game.id, company.id)
@@ -74,7 +85,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun updateGameDeveloper() {
+    fun insertGameDeveloper_shouldReplaceDataOnConflict() {
         val company = makeCompanyDao()
         val game = makeGameCache()
         val data = GameDeveloperDao(game.id, company.id)
@@ -89,7 +100,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun updateGamePublisher() {
+    fun insertGamePublisher_shouldReplaceDataOnConflict() {
         val company = makeCompanyDao()
         val game = makeGameCache()
         val data = GamePublisherDao(game.id, company.id)
@@ -104,7 +115,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findCompanyByIdThrowsErrorIfNotFound() {
+    fun findCompanyById_throwsErrorIfNotFound() {
         val observer = database?.companyDao()?.findCompanyById(2)?.test()
 
         Assert.assertNotNull(observer)
@@ -116,7 +127,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findCompanyByIdReturnsDataIfPresent() {
+    fun findCompanyById_returnsData() {
         val data = makeCompanyDao()
 
         database?.companyDao()?.insertCompany(data)
@@ -133,7 +144,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findDeveloperForGameReturnsData() {
+    fun findDeveloperForGame_returnsData() {
         val game = makeGameCache()
         val game2 = makeGameCache()
         val company1 = makeCompanyDao()
@@ -165,7 +176,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findPublishersForGameReturnsData() {
+    fun findPublishersForGame_returnsData() {
         val game = makeGameCache()
         val game2 = makeGameCache()
         val company1 = makeCompanyDao()
@@ -197,7 +208,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findDeveloperForGameReturnsEmptyList() {
+    fun findDeveloperForGame_returnsEmptyList() {
 
         val game = makeGameCache()
         database?.gamesDao()?.insertGame(game)
@@ -216,7 +227,7 @@ class CompanyDaoServiceTest {
     }
 
     @Test
-    fun findPublishersForGameReturnsEmptyList() {
+    fun findPublishersForGame_returnsEmptyList() {
 
         val game = makeGameCache()
         database?.gamesDao()?.insertGame(game)

--- a/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/CompanyDaoService.kt
+++ b/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/CompanyDaoService.kt
@@ -1,9 +1,6 @@
 package com.piticlistudio.playednext.data.repository.datasource.dao
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy
-import android.arch.persistence.room.Query
+import android.arch.persistence.room.*
 import com.piticlistudio.playednext.data.entity.dao.CompanyDao
 import com.piticlistudio.playednext.data.entity.dao.GameDeveloperDao
 import com.piticlistudio.playednext.data.entity.dao.GamePublisherDao
@@ -15,7 +12,7 @@ interface CompanyDaoService {
     @Query("select * from company where id = :id")
     fun findCompanyById(id: Long): Single<CompanyDao>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insertCompany(data: CompanyDao): Long
 
     @Query("select company.* from company " +

--- a/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GameDaoService.kt
+++ b/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GameDaoService.kt
@@ -1,9 +1,6 @@
 package com.piticlistudio.playednext.data.repository.datasource.dao
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy
-import android.arch.persistence.room.Query
+import android.arch.persistence.room.*
 import com.piticlistudio.playednext.data.entity.dao.GameDao
 import io.reactivex.Flowable
 import io.reactivex.Single
@@ -17,8 +14,11 @@ interface GameDaoService {
     @Query("select * from game where id = :id")
     fun findGameById(id: Long): Single<GameDao>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     fun insertGame(game: GameDao): Long
+
+    @Update
+    fun updateGame(game: GameDao): Int
 
     @Query("select * from game where name LIKE :name")
     fun findByName(name: String): Flowable<List<GameDao>>

--- a/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GameLocalImpl.kt
+++ b/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GameLocalImpl.kt
@@ -1,5 +1,6 @@
 package com.piticlistudio.playednext.data.repository.datasource.dao
 
+import android.database.sqlite.SQLiteConstraintException
 import com.piticlistudio.playednext.data.entity.mapper.datasources.GameDaoMapper
 import com.piticlistudio.playednext.data.repository.datasource.GameDatasourceRepository
 import com.piticlistudio.playednext.domain.model.Game
@@ -24,7 +25,13 @@ class GameLocalImpl @Inject constructor(private val dao: GameDaoService,
 
     override fun save(domainModel: Game): Completable {
         return Completable.defer {
-            dao.insertGame(mapper.mapFromModel(domainModel))
+            mapper.mapFromModel(domainModel).also {
+                try {
+                    dao.insertGame(it)
+                } catch (e: SQLiteConstraintException) {
+                    dao.updateGame(it)
+                }
+            }
             Completable.complete()
         }
     }

--- a/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GenreDaoService.kt
+++ b/app/src/main/java/com/piticlistudio/playednext/data/repository/datasource/dao/GenreDaoService.kt
@@ -11,7 +11,7 @@ import io.reactivex.Single
 @Dao
 interface GenreDaoService {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(data: GenreDao): Long
 
     @Query("select genre.* from genre " +


### PR DESCRIPTION
Changes policy data on insert conflict. Company and genre entities are ignored, and Game conflict throws an Exception.
An update method has been added for the game entities, to allow updating elements.